### PR TITLE
Fix git clone command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,7 +257,7 @@ Run the program directly on your host.
 Download and use:
 
 ```
-git -b python clone https://github.com/Charles94jp/NameSilo-DDNS.git
+git clone -b python https://github.com/Charles94jp/NameSilo-DDNS.git
 ```
 
 The python 3 environment is required. The httpx module also needs to be installed.

--- a/readme.zh-CN.md
+++ b/readme.zh-CN.md
@@ -259,7 +259,7 @@ ls -lh log/DDNS*.log*
 下载即用
 
 ```
-git -b python clone https://github.com/Charles94jp/NameSilo-DDNS.git
+git clone -b python https://github.com/Charles94jp/NameSilo-DDNS.git
 ```
 
 需要使用python3来运行，python需要安装httpx模块：


### PR DESCRIPTION
The original git clone command does not work on my machine (ArchLinux, git version 2.39.1):

```shell
git -b python clone https://github.com/Charles94jp/NameSilo-DDNS.git
```

```text
unknown option: -b
usage: git [-v | --version] [-h | --help] [-C <path>] [-c <name>=<value>]
           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]
           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]
           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]
           [--super-prefix=<path>] [--config-env=<name>=<envvar>]
           <command> [<args>]
```

This works:

```shell
git clone -b python https://github.com/Charles94jp/NameSilo-DDNS.git
```