### PR TITLE
修复namesilo_client.py在处理数据bug

### DIFF
--- a/lib/namesilo_client.py
+++ b/lib/namesilo_client.py
@@ -105,6 +105,8 @@ class NameSiloClient:
                 if record.find(f'<host>{_domain}</host>') != -1:
                     r = record
                     break
+            if type(r) == list:
+                r = "".join(r)
             r = r.split('</record_id>')
             domain['record_id'] = r[0].split('<record_id>')[-1]
             domain['domain_ip'] = r[1].split('<value>')[1].split('</value>')[0]


### PR DESCRIPTION
修复以下报错：
/mnt/e/VSCodeProjects/NameSilo-DDNS/ddns.py:37: DeprecationWarning: ssl.OP_NO_SSL*/ssl.OP_NO_TLS* options are deprecated
  _SSL_CONTEXT.options ^= ssl.OP_NO_TLSv1
Traceback (most recent call last):
  File "/mnt/e/VSCodeProjects/NameSilo-DDNS/ddns.py", line 226, in <module>
    main()
  File "/mnt/e/VSCodeProjects/NameSilo-DDNS/ddns.py", line 222, in main
    ddns.start()
  File "/mnt/e/VSCodeProjects/NameSilo-DDNS/ddns.py", line 151, in start
    self._namesilo_client.fetch_domains_info()
  File "/mnt/e/VSCodeProjects/NameSilo-DDNS/lib/namesilo_client.py", line 80, in fetch_domains_info
    self._list_dns_api(domain)
  File "/mnt/e/VSCodeProjects/NameSilo-DDNS/lib/namesilo_client.py", line 108, in _list_dns_api
    r = r.split('</record_id>')
AttributeError: 'list' object has no attribute 'split'